### PR TITLE
Re-set BPZDATAPATH when unpickling BPZ_lite class

### DIFF
--- a/rail/estimation/algos/bpz_lite.py
+++ b/rail/estimation/algos/bpz_lite.py
@@ -381,3 +381,9 @@ class BPZ_lite(Estimator):
         else:
             pz_dict = {'zmode': zmode, 'pz_pdf': pdfs}
             return pz_dict
+
+
+    def __setstate__(self, state):
+        # Set BPZDATAPATH when unpickling so state is restored
+        self.__dict__.update(state)
+        os.environ["BPZDATAPATH"] = self.data_path


### PR DESCRIPTION
Currently if you pickle a BPZ_lite class and then unpickle it in a new process (as wo do in TXPipe, since we separate the train and estimate phases) then the BPZDATAPATH environment variable is no longer set and there is an import failure later when importing the desc_bpz library.

This adds a `__setstate__` special method to BPZ_lite that restores it. This is automatically called when you unpickle a class.