### PR TITLE
update zgrid bound and test values addressing #101

### DIFF
--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -4,22 +4,23 @@ from rail.evaluation.metrics.cdeloss import CDELoss
 import qp
 
 # values for metrics
-OUTRATE = 0.5900099
-KSVAL = 0.5964912
-CVMVAL = 42.94254
-ADVAL_ALL = 224.416922
-ADVAL_CUT = -0.655614
-CDEVAL = -45.9017221
+OUTRATE = 0.0
+KSVAL = 0.367384
+CVMVAL = 20.63155
+ADVAL_ALL = 82.51480
+ADVAL_CUT = 1.10750
+CDEVAL = -4.31200
 
 
 def construct_test_ensemble():
     np.random.seed(87)
+    nmax = 2.5
     NPDF = 399
-    true_zs = np.random.uniform(high=2.5, size=NPDF)
+    true_zs = np.random.uniform(high=nmax, size=NPDF)
     locs = np.expand_dims(true_zs + np.random.normal(0.0, 0.01, NPDF), -1)
     scales = np.ones((NPDF, 1)) * 0.1 + np.random.uniform(size=(NPDF, 1)) * .05
     n_ens = qp.Ensemble(qp.stats.norm, data=dict(loc=locs, scale=scales))
-    zgrid = np.linspace(0, 1, 301)
+    zgrid = np.linspace(0, nmax, 301)
     grid_ens = n_ens.convert_to(qp.interp_gen, xvals=zgrid)
     return zgrid, true_zs, grid_ens
 


### PR DESCRIPTION
Fixes the incorrect zgrid that messes up PDF distributions, and chokes the temporarily touchy qp quantile distribution mentioned in #101 