### PR TITLE
add additional install instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,17 @@ Now to install RAIL, you need to:
     If you only want to install the dependencies for a piece of RAIL, you can change the install option. E.g. to install only the dependencies for the Creation Module, run `pip install .[creation]` or `pip install .[estimation]` respectively. For other install options, look at the keys for the `extras_require` dictionary at the top of `setup.py`.
     - If you are developing RAIL, you should install with the `-e` flag, e.g. `pip install -e .[all]`. This means that any changes you make to the RAIL codebase will propagate to imports of RAIL in your scripts and notebooks.
 
+On some systems that are slightly out of date, e.g. an older version of python's `setuptools`, there can be some problems installing packages hosted on GitHub rather than PyPi.  We recommend that you update your system; however, some users have still reported problems with installation of subpackages necessary for `FZBoost` and `bpz_lite`.  If this occurs, try the following procedure:
+For FZBoost:
+- install `xgboost` with the command `pip install xgboost==0.90.0`
+- install FlexCode with `pip install FlexCode[all]
+- ensure that you are in the directory where you cloned RAIL, and reinstall with `pip install .[all]`
+
+For bpz_lite:
+- cd to a directory where you wish to clone the DESC_BPZ package and run `git clone https://github.com/LSSTDESC/DESC_BPZ.git`
+- cd to the DESC_BPZ directory and run `python setup.py install` (add `--user` if you are on a shared system such as NERSC)
+- cd to the directory where you cloned RAIL, and reinstall with `pip install .[all]`
+
 Once you have installed RAIL, you can import the package (via `import rail`) in any of your scripts and notebooks.
 For examples demonstrating how to use the different pieces, see the notebooks in the `examples/` directory.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Now to install RAIL, you need to:
 2. Change directories so that you are in the RAIL root directory.
 3. Run one of the following commands, depending on your use case:
 
-    - If you are not developing RAIL and just want to install the package for use in some other project, you can run the command `pip install .[all]`. This will download the entire RAIL package. 
+    - If you are not developing RAIL and just want to install the package for use in some other project, you can run the command `pip install .[all]` (Note: if you are using zsh, e.g. on a Mac, you will need to instead run `pip install '.[all]'`). This will download the entire RAIL package. 
     If you only want to install the dependencies for a piece of RAIL, you can change the install option. E.g. to install only the dependencies for the Creation Module, run `pip install .[creation]` or `pip install .[estimation]` respectively. For other install options, look at the keys for the `extras_require` dictionary at the top of `setup.py`.
     - If you are developing RAIL, you should install with the `-e` flag, e.g. `pip install -e .[all]`. This means that any changes you make to the RAIL codebase will propagate to imports of RAIL in your scripts and notebooks.
 
@@ -27,17 +27,17 @@ On some systems that are slightly out of date, e.g. an older version of python's
 If all of the estimation algorithms are listed as `not avaialble` there may have been a problem installing `qp`.  Try:
 - cd to a directory where you wish to clone qp and run `git clone https://github.com/LSSTDESC/qp.git`
 - cd to the qp directory and run `python setup.py install`
-- cd to the directory where you cloned RAIL, and reinstall with `pip install .[all]`
+- cd to the directory where you cloned RAIL, and reinstall with `pip install .[all]`, or `pip install '.[all]'` if using zsh
 
 For FZBoost:
 - install `xgboost` with the command `pip install xgboost==0.90.0`
 - install FlexCode with `pip install FlexCode[all]
-- ensure that you are in the directory where you cloned RAIL, and reinstall with `pip install .[all]`
+- ensure that you are in the directory where you cloned RAIL, and reinstall with `pip install .[all]`, or `pip install '.[all]'` if using zsh
 
 For bpz_lite:
 - cd to a directory where you wish to clone the DESC_BPZ package and run `git clone https://github.com/LSSTDESC/DESC_BPZ.git`
 - cd to the DESC_BPZ directory and run `python setup.py install` (add `--user` if you are on a shared system such as NERSC)
-- cd to the directory where you cloned RAIL, and reinstall with `pip install .[all]`
+- cd to the directory where you cloned RAIL, and reinstall with `pip install .[all]`, or `pip install '.[all]'` if using zsh
 
 Once you have installed RAIL, you can import the package (via `import rail`) in any of your scripts and notebooks.
 For examples demonstrating how to use the different pieces, see the notebooks in the `examples/` directory.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ Now to install RAIL, you need to:
     - If you are developing RAIL, you should install with the `-e` flag, e.g. `pip install -e .[all]`. This means that any changes you make to the RAIL codebase will propagate to imports of RAIL in your scripts and notebooks.
 
 On some systems that are slightly out of date, e.g. an older version of python's `setuptools`, there can be some problems installing packages hosted on GitHub rather than PyPi.  We recommend that you update your system; however, some users have still reported problems with installation of subpackages necessary for `FZBoost` and `bpz_lite`.  If this occurs, try the following procedure:
+
+If all of the estimation algorithms are listed as `not avaialble` there may have been a problem installing `qp`.  Try:
+- cd to a directory where you wish to clone qp and run `git clone https://github.com/LSSTDESC/qp.git`
+- cd to the qp directory and run `python setup.py install`
+- cd to the directory where you cloned RAIL, and reinstall with `pip install .[all]`
+
 For FZBoost:
 - install `xgboost` with the command `pip install xgboost==0.90.0`
 - install FlexCode with `pip install FlexCode[all]

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ estimation_codes = {
 }
 
 # dependencies for the Evaluation module
-evaluation_extras = []
+evaluation_extras = ["seaborn"]
 
 
 # compile the extras_require dictionary


### PR DESCRIPTION
After some problems with installing RAIL were reported by a user, Shahab and Markus asked me to expand the installation instructions a bit, this PR just adds some text to the README.md covering what to do if qp, DESC_BPZ, and FlexCode do not install correctly.