### PR TITLE
Issue/161/testskip

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ name: rail
 
 on:
   push:
-    branches: [ issue/161/testskip ]
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ name: rail
 
 on:
   push:
-    branches: [ main ]
+    branches: [ issue/161/testskip ]
   pull_request:
     branches: [ main ]
 
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
         mpi: [ openmpi ]
     steps:
     - uses: actions/checkout@v2

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -2,9 +2,14 @@
 Installation
 ************
 
-First, it is recommended that you create a new virtual environment for RAIL.
-For example, to create a conda environment named "rail" that has the latest version of python and pip, run the command `conda create -n rail pip`.
-You can then run the command `conda activate rail` to activate this environment.  We note that the particular estimator `Delight` is built with `Cython` and uses `openmp`.  Mac has dropped native support for `openmp`, which will likely cause problems when trying to run the `delightPZ` estimation code in RAIL.  See the notes below for instructions on installing Delight if you wish to use this particular estimator.
+RAIL has multiple dependencies that are sensitive to out-of-date code versions, therefore it is strongly recommended that you create a new dedicated virtual environment for RAIL to avoid problems with pip/conda failing to update some packages that you have previously installed during installation of RAIL.  Due to changes in `scipy` array broadcasting with v1.8.0, we also strongly recommend using scipy >= 1.8.0, and note that scipy 1.8.0 requires python >= 3.8, and therefore recommend against using python versions of 3.7 or below.
+
+If you want to add the conda environment that you are about to create as a kernel that you can use in a Jupyter notebook, see below in the :ref: `Adding your kernel to jupyter` section.
+
+To create a conda environment named "[name-for-your-env]" that has a specific version of python (in this case 3.9) and pip, run the command:
+`conda create -n [name-for-your-env] pip python=3.9`.
+Where you have replaced [name-for-your-env] with whatever name you wish to use, e.g. `rail`.
+You can then run the command `conda activate [name-for-your-env]` to activate this environment.  We are now ready to install RAIL.  Before we do that, though, we note that the particular estimator `Delight` is built with `Cython` and uses `openmp`.  Mac has dropped native support for `openmp`, which will likely cause problems when trying to run the `delightPZ` estimation code in RAIL.  See the notes below for instructions on installing Delight if you wish to use this particular estimator.
 
 Now to install RAIL, you need to:
 1. `Clone this repo <https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository-from-github/cloning-a-repository>`_ to your local workspace.
@@ -39,7 +44,15 @@ For bpz_lite:
 
 Once you have installed RAIL, you can import the package (via `import rail`) in any of your scripts and notebooks.
 For examples demonstrating how to use the different pieces, see the notebooks in the `examples/` directory.
-  
+
+
+Adding your kernel to jupyter
+========================
+If you want to use the kernel that you have just created to run RAIL example demos, then you may need to explicitly add an ipython kernel.  You may need to first install ipykernel with `conda install ipykernel`.  You can do then add your kernel with the following command, making sure that you have the conda environment that you wish to add activated.  From your environment, execute the command:
+`python -m ipykernel install --user --name [nametocallnewkernel]`
+(you may or may not need to prepend `sudo` depending on your permissions).  When you next start up Jupyter you should see a kernel with your new name as an option, including using the Jupyter interface at NERSC.
+
+
 Requirements
 ============
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -4,21 +4,22 @@ Installation
 
 RAIL has multiple dependencies that are sensitive to out-of-date code versions, therefore it is strongly recommended that you create a new dedicated virtual environment for RAIL to avoid problems with pip/conda failing to update some packages that you have previously installed during installation of RAIL.  Due to changes in `scipy` array broadcasting with v1.8.0, we also strongly recommend using scipy >= 1.8.0, and note that scipy 1.8.0 requires python >= 3.8, and therefore recommend against using python versions of 3.7 or below.
 
-If you want to add the conda environment that you are about to create as a kernel that you can use in a Jupyter notebook, see below in the :ref: `Adding your kernel to jupyter` section.
+If you want to add the conda environment that you are about to create as a kernel that you can use in a Jupyter notebook, see the `Adding your kernel to jupyter` section further down on this page.
 
-To create a conda environment named "[name-for-your-env]" that has a specific version of python (in this case 3.9) and pip, run the command:
-`conda create -n [name-for-your-env] pip python=3.9`.
-Where you have replaced [name-for-your-env] with whatever name you wish to use, e.g. `rail`.
-You can then run the command `conda activate [name-for-your-env]` to activate this environment.  We are now ready to install RAIL.  Before we do that, though, we note that the particular estimator `Delight` is built with `Cython` and uses `openmp`.  Mac has dropped native support for `openmp`, which will likely cause problems when trying to run the `delightPZ` estimation code in RAIL.  See the notes below for instructions on installing Delight if you wish to use this particular estimator.
+| To create a conda environment named "[name-for-your-env]" that has a specific version of python (in this case 3.9) and pip, run the command:
+| `conda create -n [name-for-your-env] pip python=3.9`.
+|Where you have replaced [name-for-your-env] with whatever name you wish to use, e.g. `rail`.
+| You can then run the command `conda activate [name-for-your-env]` to activate this environment.  We are now ready to install RAIL.  Before we do that, though, we note that the particular estimator `Delight` is built with `Cython` and uses `openmp`.  Mac has dropped native support for `openmp`, which will likely cause problems when trying to run the `delightPZ` estimation code in RAIL.  See the notes below for instructions on installing Delight if you wish to use this particular estimator.
 
-Now to install RAIL, you need to:
-1. `Clone this repo <https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository-from-github/cloning-a-repository>`_ to your local workspace.
-2. Change directories so that you are in the RAIL root directory.
-3. Run one of the following commands, depending on your use case:
+| Now to install RAIL, you need to:
+| 1. `Clone this repo <https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository-from-github/cloning-a-repository>`_ to your local workspace.
+| 2. Change directories so that you are in the RAIL root directory. 3. Run one of the following commands, depending on your use case:
 
   - If you are not developing RAIL and just want to install the package for use in some other project, you can run the command `pip install .[all]` (or `pip install '.[all]'` if you are using zsh, note the single quotes). This will download the entire RAIL package.
-    - If you are installing RAIL on a Mac, as noted above the `delightPZ` estimator requires that your machine's `gcc` be set up to work with `openmp`. If you are installing on a Mac and do not plan on using `delightPZ`, then you can simply install RAIL with `pip install .[base]` rather than `pip install .[all]`, which will skip the Delight package.  If you are on a Mac and *do* expect to run `delightPZ`, then follow the instructions `here <https://github.com/LSSTDESC/Delight/blob/master/Mac_installation.md>`_ to install Delight before running `pip install .[all]`.
-  If you only want to install the dependencies for a specific piece of RAIL, you can change the install option. E.g. to install only the dependencies for the Creation Module or the Estimation Module, run `pip install .[creation]` or `pip install .[estimation]` respectively. For other install options, look at the keys for the `extras_require` dictionary at the top of `setup.py`.
+    
+  - If you are installing RAIL on a Mac, as noted above the `delightPZ` estimator requires that your machine's `gcc` be set up to work with `openmp`. If you are installing on a Mac and do not plan on using `delightPZ`, then you can simply install RAIL with `pip install .[base]` rather than `pip install .[all]`, which will skip the Delight package.  If you are on a Mac and *do* expect to run `delightPZ`, then follow the instructions `here <https://github.com/LSSTDESC/Delight/blob/master/Mac_installation.md>`_ to install Delight before running `pip install .[all]`.
+      
+  - If you only want to install the dependencies for a specific piece of RAIL, you can change the install option. E.g. to install only the dependencies for the Creation Module or the Estimation Module, run `pip install .[creation]` or `pip install .[estimation]` respectively. For other install options, look at the keys for the `extras_require` dictionary at the top of `setup.py`.
   - If you are developing RAIL, you should install with the `-e` flag, e.g. `pip install -e .[all]`. This means that any changes you make to the RAIL codebase will propagate to imports of RAIL in your scripts and notebooks.
 
 Note the Creation Module depends on pzflow, which has an optional GPU-compatible installation.

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ install_requires = [
 ]
 
 # dependencies for the Creation module
-creation_extras = ["pzflow>=2.0.7"]
+creation_extras = ["pzflow>=2.0.7,<3.0.0"]
 
 # dependencies required for all estimators in the Estimation module
 estimation_extras = [

--- a/tests/test_algos.py
+++ b/tests/test_algos.py
@@ -14,6 +14,9 @@ except ImportError:
     pass
 from rail.estimation.algos import bpz_lite, pzflow, knnpz
 from pzflow import Flow
+import scipy
+sci_ver_str = scipy.__version__.split('.')
+sci_ver = int(sci_ver_str[0]) + 0.1 * int(sci_ver_str[1])
 
 traindata = 'tests/data/training_100gal.hdf5'
 validdata = 'tests/data/validation_10gal.hdf5'
@@ -220,8 +223,10 @@ def test_delight():
         for file_ in files:
             os.remove(file_)
     os.removedirs('examples/estimation/tmp/delight_data')
-    
 
+
+@pytest.mark.skipif(sci_ver < 1.79,
+                    reason="mixmod parameterization known to break for scipy<1.8 due to array broadcast change")
 def test_KNearNeigh():
     def_bands = ['u', 'g', 'r', 'i', 'z', 'y']
     refcols = [f"mag_{band}_lsst" for band in def_bands]

--- a/tests/test_algos.py
+++ b/tests/test_algos.py
@@ -16,7 +16,7 @@ from rail.estimation.algos import bpz_lite, pzflow, knnpz
 from pzflow import Flow
 import scipy
 sci_ver_str = scipy.__version__.split('.')
-sci_ver = int(sci_ver_str[0]) + 0.1 * int(sci_ver_str[1])
+
 
 traindata = 'tests/data/training_100gal.hdf5'
 validdata = 'tests/data/validation_10gal.hdf5'
@@ -225,7 +225,7 @@ def test_delight():
     os.removedirs('examples/estimation/tmp/delight_data')
 
 
-@pytest.mark.skipif(sci_ver < 1.79,
+@pytest.mark.skipif(int(sci_ver_str[0]) < 2 and int(sci_ver_str[1])<8,
                     reason="mixmod parameterization known to break for scipy<1.8 due to array broadcast change")
 def test_KNearNeigh():
     def_bands = ['u', 'g', 'r', 'i', 'z', 'y']


### PR DESCRIPTION
This PR just adds a test skip for a scipy<1.8.0 that we know should fail for the KNearNeighPDF test that uses mixmod from qp, and also puts a (temporary) limit on the pzflow version in setup.py that will keep tests passing until John Franklin updates RAIL to reflect recent changes in pzflow.