### PR TITLE
remove inaccurate language

### DIFF
--- a/examples/creation/degradation-demo.ipynb
+++ b/examples/creation/degradation-demo.ipynb
@@ -276,7 +276,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you look at the i column, you will see there are no longer any samples with i > 25.3. You can also see that despite making the cut on the i band, there are still 100000 samples as requested. This is because after making the cut, the creator will draw more samples (and re-apply the cut) iteratively until you have as many samples as originally requested. \n",
+    "If you look at the i column, you will see there are no longer any samples with i > 25.3. The number of galaxies returned has been nearly cut in half from the input sample and, unlike the LSSTErrorModel degrader, is not equal to the number of input objects.  Users should note that with degraders that remove galaxies from the sample the size of the output sample will not equal that of the input sample.\n",
     "\n",
     "One more note: it is easy to use the QuantityCut degrader as a SNR cut on the magnitudes. The magnitude equation is $m = -2.5 \\log(f)$. Taking the derivative, we have\n",
     "$$\n",
@@ -484,7 +484,7 @@
    "hash": "33169e9e67880b1853f4eac3eefbf27d2cf9aef466064efe02e233d73165a438"
   },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -498,7 +498,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.8.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Trivial change that removes inaccurate language that confused someone, as degraders that remove objects no longer sample new objects to get to the same number of objects as the input.