### PR TITLE
docs: fix typo in `docs/source/installation.rst`

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -27,7 +27,7 @@ For instructions, see the `pzflow Github repo <https://github.com/jfcrenshaw/pzf
 
 On some systems that are slightly out of date, e.g. an older version of python's `setuptools`, there can be some problems installing packages hosted on GitHub rather than PyPi.  We recommend that you update your system; however, some users have still reported problems with installation of subpackages necessary for `FZBoost` and `bpz_lite`.  If this occurs, try the following procedure:
 
-If all of the estimation algorithms are listed as `not avaialble` there may have been a problem installing `qp`.  Try:
+If all of the estimation algorithms are listed as `not available there may have been a problem installing `qp`.  Try:
 - cd to a directory where you wish to clone qp and run `git clone https://github.com/LSSTDESC/qp.git`
 - cd to the qp directory and run `python setup.py install`
 - cd to the directory where you cloned RAIL, and reinstall with `pip install .[all]`, or `pip install '.[all]'` if using zsh


### PR DESCRIPTION
`avaialble` ⭢ `available`