### PR TITLE
Dealing with two issues found while using TXPipe

### DIFF
--- a/rail/creation/degradation/grid_selection.py
+++ b/rail/creation/degradation/grid_selection.py
@@ -124,6 +124,7 @@ class GridSelection(Degrader):
         flat_inds = [item for sublist in keep_inds for item in sublist]
         training_data = data_hsc_like.loc[flat_inds, :]
 
+        training_data = training_data[training_data['redshift'] > 0]
         # For the pessimistic choice, also remove galaxies with z > redshift_cut from the sample
         if not np.isclose(self.config['redshift_cut'], 100.):
             training_data = training_data[training_data['redshift'] <= self.config['redshift_cut']]

--- a/rail/estimation/algos/bpz_lite.py
+++ b/rail/estimation/algos/bpz_lite.py
@@ -154,6 +154,7 @@ class Inform_BPZ_lite(CatInformer):
                                            args=(zo, alpha, km, mag, self.mo),
                                            epsrel=1.e-5)
             loglike += -2. * np.log10(pz / norm)
+        print(f"Fitting dN/dz: loglike = {loglike} for parameters {params}")
         return loglike
 
     def _find_dndz_params(self):
@@ -225,7 +226,7 @@ class Inform_BPZ_lite(CatInformer):
 class BPZ_lite(CatEstimator):
     """CatEstimator subclass to implement basic marginalized PDF for BPZ
     """
-
+    name = "BPZ_lite"
     config_options = CatEstimator.config_options.copy()
     config_options.update(zmin=Param(float, 0.0, msg="min z for grid"),
                           zmax=Param(float, 3.0, msg="max z for grid"),
@@ -491,6 +492,8 @@ class BPZ_lite(CatEstimator):
         zgrid = self.zgrid
         # Loop over all ng galaxies!
         for i in range(ng):
+            if i % 1000 == 0:
+                print(f"Estimating p(z) for galaxy {i+1} / {ng}")
             mag_0 = test_data['mags'][i, m_0_col]
             flux = test_data['flux'][i]
             flux_err = test_data['flux_err'][i]


### PR DESCRIPTION
Hi all. 

I found a couple of issues when using the newest RAIL from TXPipe:
- the `name` attribute was missing from the BPZ_lite class, which is needed to run from a YAML file correctly
- FlowEngine sometimes produces objects with z < 0. This was causing a crash in the BPZ dN/dz fitting, so I added a cut on these.  Might also want to look at removing them on generation, but I wasn't sure how to do that.

I also added a couple of print-outs to give users feedback on progress, but if people don't like these I can remove them.