### PR TITLE
fix errors, remove old sz write, switch rng form

### DIFF
--- a/tests/test_algos.py
+++ b/tests/test_algos.py
@@ -264,7 +264,6 @@ def test_KNearNeigh():
     results, rerun_results, rerun3_results = one_algo("KNN", train_algo, pz_algo, train_config_dict, estim_config_dict)
     # assert np.isclose(results.ancil['zmode'], zb_expected).all()
     assert np.isclose(results.ancil['zmode'], rerun_results.ancil['zmode']).all()
-    os.remove('TEMPZFILE.out')
 
 
 def test_catch_bad_bands():


### PR DESCRIPTION
Super simple PR to remove an unnecessary data frame copy that causes some annoying warnings; removal of writeout of the spec-z array that was left over from debugging, and switching the random number handling after Joe's comment about reproducibility in pipelines. 