### PR TITLE
add nthread to regression params

### DIFF
--- a/rail/estimation/algos/flexzboost.py
+++ b/rail/estimation/algos/flexzboost.py
@@ -104,7 +104,7 @@ class Inform_FZBoost(CatInformer):
                           bands=Param(list, def_bands, msg="bands to use in estimation"),
                           err_bands=Param(list, def_err_bands, msg="error column names to use in estimation"),
                           ref_band=Param(str, "mag_i_lsst", msg="band to use in addition to colors"),
-                          regression_params=Param(dict, {'max_depth': 8, 'objective': 'reg:squarederror', 'nthread': 1},
+                          regression_params=Param(dict, {'max_depth': 8, 'objective': 'reg:squarederror', 'nthread': 4},
                                                   msg="dictionary of options passed to flexcode, includes "
                                                   "max_depth (int), and objective, which should be set "
                                                   " to reg:squarederror"))

--- a/rail/estimation/algos/flexzboost.py
+++ b/rail/estimation/algos/flexzboost.py
@@ -104,7 +104,7 @@ class Inform_FZBoost(CatInformer):
                           bands=Param(list, def_bands, msg="bands to use in estimation"),
                           err_bands=Param(list, def_err_bands, msg="error column names to use in estimation"),
                           ref_band=Param(str, "mag_i_lsst", msg="band to use in addition to colors"),
-                          regression_params=Param(dict, {'max_depth': 8, 'objective': 'reg:squarederror'},
+                          regression_params=Param(dict, {'max_depth': 8, 'objective': 'reg:squarederror', 'nthread': 1},
                                                   msg="dictionary of options passed to flexcode, includes "
                                                   "max_depth (int), and objective, which should be set "
                                                   " to reg:squarederror"))

--- a/tests/test_algos.py
+++ b/tests/test_algos.py
@@ -118,7 +118,8 @@ def test_flexzboost():
                          'basis_system': 'cosine',
                          'regression_params': {'max_depth': 8,
                                                'objective':
-                                               'reg:squarederror'},
+                                               'reg:squarederror',
+                                               'nthread': 1},
                          'hdf5_groupname': 'photometry',
                          'model': 'model.tmp'}
     estim_config_dict = {'hdf5_groupname': 'photometry',

--- a/tests/test_algos.py
+++ b/tests/test_algos.py
@@ -119,7 +119,7 @@ def test_flexzboost():
                          'regression_params': {'max_depth': 8,
                                                'objective':
                                                'reg:squarederror',
-                                               'nthread': 1},
+                                               'nthread': 4},
                          'hdf5_groupname': 'photometry',
                          'model': 'model.tmp'}
     estim_config_dict = {'hdf5_groupname': 'photometry',


### PR DESCRIPTION
draft just to see if adding nthread param to regression params makes the GH action run faster.  It doesn't seem to affect cpu time, but does sometimes affect wall time in my tests.  And, I missed that the default value is `-1` not `1`, which sets it to try to use all available processors.  Setting default to 1 might speed things up.