### PR TITLE
Specify qp-prob version in RAIL

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "minisom",
     "scipy>=1.9.0",
     "pz-hyperbolic-temp",
-    "qp-prob",
+    "qp-prob==0.6.3",
     "scikit-learn",
     "pzflow",
     "healpy",


### PR DESCRIPTION
This PR is associated with [issue #272](https://github.com/LSSTDESC/RAIL/issues/272)

Here I am specifying the qp-prob version in support of qp [issue #25](https://github.com/LSSTDESC/qp/issues/25) moving RAIL metrics over to qp. With the version of qp-prob pinned, we can update qp and increment the version in PyPI without causing regressions in RAIL.  

For additional context, please see the google doc linked in the #desc-pz-rail slack channel [here](https://lsstc.slack.com/archives/CQGKM0WKD/p1666124571286259).