### PR TITLE
Fix crash in somocluSOM.py when training set length is a multiple of 1000

### DIFF
--- a/src/rail/estimation/algos/somocluSOM.py
+++ b/src/rail/estimation/algos/somocluSOM.py
@@ -63,8 +63,9 @@ def get_bmus(som, data, step=1000):  # pragma: no cover
         else:
             dmap = som.get_surface_state(data[i*step:i*step+step])
             return som.get_bmus(dmap).tolist()
+    n_chunk = int(np.ceil(len(data) / step))
     with ProcessPool() as p:
-        bmus = p.map(func, np.arange(int(len(data)/step)+1))
+        bmus = p.map(func, np.arange(n_chunk))
     bmus_array = np.asarray(bmus).astype(np.int)
     return bmus_array.reshape(bmus_array.shape[0]*bmus_array.shape[1], 2)[:len(data)]
 


### PR DESCRIPTION
When the length of the training set in somocluSOM is a multiple of 1000 it causes a crash, because of a mistake in calculating the number of chunks to split the data into. This fixes that error.