### PR TITLE
Deprecate Brier and PIT in RAIL in favor of qp implementation

### DIFF
--- a/examples/evaluation/utils.py
+++ b/examples/evaluation/utils.py
@@ -204,7 +204,7 @@ def plot_pit_qq(pdfs, zgrid, ztrue, bins=None, title=None, code=None,
     plt.xlim(-0.001, 1.001)
     plt.title(title)
     if show_pit:
-        fzdata = qp.Ensemble(qp.interp, data=dict(xvals=zgrid, yvals=pdfs))
+        fzdata = Ensemble(interp, data=dict(xvals=zgrid, yvals=pdfs))
         pitobj = PIT(fzdata, ztrue)
         pit_vals = np.array(pitobj.pit_samps)
         pit_out_rate = pitobj.evaluate_PIT_outlier_rate()
@@ -506,18 +506,18 @@ class Sample(Ensemble):
         return text
 
     def plot_pdfs(self, gals, show_ztrue=True, show_photoz_mode=False):
-        colors = utils.plot_pdfs(self, gals, show_ztrue=show_ztrue,
+        colors = plot_pdfs(self, gals, show_ztrue=show_ztrue,
                                  show_photoz_mode=show_photoz_mode)
         return colors
 
     def plot_old_valid(self, gals=None, colors=None):
-        old_metrics_table = utils.plot_old_valid(self, gals=gals, colors=colors)
+        old_metrics_table = plot_old_valid(self, gals=gals, colors=colors)
         return old_metrics_table
 
     def plot_pit_qq(self, bins=None, label=None, title=None, show_pit=True,
                     show_qq=True, show_pit_out_rate=True, savefig=False):
         """Make plot PIT-QQ as Figure 2 from Schmidt et al. 2020."""
-        fig_filename = utils.plot_pit_qq(self, bins=bins, label=label, title=title,
+        fig_filename = plot_pit_qq(self, bins=bins, label=label, title=title,
                                          show_pit=show_pit, show_qq=show_qq,
                                          show_pit_out_rate=show_pit_out_rate,
                                          savefig=savefig)

--- a/examples/evaluation/utils.py
+++ b/examples/evaluation/utils.py
@@ -3,8 +3,7 @@ from matplotlib import gridspec
 import numpy as np
 import pandas as pd
 import seaborn as sns
-from rail.evaluation.metrics.pit import *
-#from metrics import *
+from qp.metrics.pit import PIT
 from IPython.display import Markdown
 import h5py
 import os
@@ -207,9 +206,8 @@ def plot_pit_qq(pdfs, zgrid, ztrue, bins=None, title=None, code=None,
     if show_pit:
         fzdata = qp.Ensemble(qp.interp, data=dict(xvals=zgrid, yvals=pdfs))
         pitobj = PIT(fzdata, ztrue)
-        spl_ens, metamets = pitobj.evaluate()
-        pit_vals = np.array(pitobj._pit_samps)
-        pit_out_rate = PITOutRate(pit_vals, spl_ens).evaluate()
+        pit_vals = np.array(pitobj.pit_samps)
+        pit_out_rate = pitobj.evaluate_PIT_outlier_rate()
 
         try:
             y_uni = float(len(pit_vals)) / float(bins)
@@ -257,11 +255,8 @@ def plot_pit_qq(pdfs, zgrid, ztrue, bins=None, title=None, code=None,
 def ks_plot(pitobj, n_quant=100):
     """ KS test illustration.
     Ancillary function to be used by class KS."""
-    #pits = ks._pits
-    spl_ens, metamets = pitobj.evaluate()
-    pits = np.array(pitobj._pit_samps)
-    ksobj = PITKS(pits, spl_ens)
-    stat_and_pval = ksobj.evaluate()
+    pits = np.array(pitobj.pit_samps)
+    stat_and_pval = pitobj.evaluate_PIT_KS()
     xvals = np.linspace(0., 1., n_quant)
     yvals = np.array([np.histogram(pits, bins=len(xvals))[0]])
     pit_cdf = Ensemble(interp, data=dict(xvals=xvals, yvals=yvals)).cdf(xvals)[0]

--- a/examples/goldenspike/attic/eval_utils.py
+++ b/examples/goldenspike/attic/eval_utils.py
@@ -3,7 +3,7 @@ from matplotlib import gridspec
 import numpy as np
 import pandas as pd
 import seaborn as sns
-from rail.evaluation.metrics.pit import *
+from qp.metrics.pit import PIT
 from qp.ensemble import Ensemble
 from qp import interp
 
@@ -58,9 +58,7 @@ def plot_pit_qq(pdf_ens, ztrue, qbins=101, title=None, code=None,
     ax0 = plt.subplot(gs[0])
 
     pitobj = PIT(pdf_ens, ztrue)
-    spl_ens, metamets = pitobj.evaluate()
-    pit_vals = np.array(pitobj._pit_samps)
-    pit_out_rate = PITOutRate(pit_vals, spl_ens).evaluate()
+    pit_vals = np.array(pitobj.pit_samps)
 
     # #################
     q_theory = np.linspace(0., 1., qbins)
@@ -122,11 +120,8 @@ def plot_pit_qq(pdf_ens, ztrue, qbins=101, title=None, code=None,
 def ks_plot(pitobj, n_quant=100, savefig=True, figname='default_ksplot.jpg'):
     """ KS test illustration.
     Ancillary function to be used by class KS."""
-    #pits = ks._pits
-    spl_ens, metamets = pitobj.evaluate()
-    pits = np.array(pitobj._pit_samps)
-    ksobj = PITKS(pits, spl_ens)
-    stat_and_pval = ksobj.evaluate()
+    pits = np.array(pitobj.pit_samps)
+    stat_and_pval = pitobj.evaluate_PIT_KS()
     xvals = np.linspace(0., 1., n_quant)
     yvals = np.array([np.histogram(pits, bins=len(xvals))[0]])
     pit_cdf = Ensemble(interp, data=dict(xvals=xvals, yvals=yvals)).cdf(xvals)[0]

--- a/examples/goldenspike/attic/goldenspike.py
+++ b/examples/goldenspike/attic/goldenspike.py
@@ -176,6 +176,7 @@ def main():
 
             # calculate PIT values, takes a qp ensemble and the true z's
             pitobj = PIT(pz_data, z_true)
+            pit_vals = pitobj.pit_samps
             metamets = pitobj.calculate_pit_meta_metrics()
             # KS
             ks_stat_and_pval = metamets['ks']

--- a/examples/goldenspike/attic/goldenspike.py
+++ b/examples/goldenspike/attic/goldenspike.py
@@ -7,7 +7,7 @@ from rail.creation import Creator
 import rail.creation.degradation
 from rail.creation.degradation.lsst_error_model import LSSTErrorModel
 from rail.estimation.estimator import Estimator
-from rail.evaluation.metrics.pit import *
+from qp.metrics.pit import PIT
 import rail.evaluation.metrics.pointestimates as pe
 from rail.evaluation.metrics.cdeloss import CDELoss
 import tables_io
@@ -176,14 +176,11 @@ def main():
 
             # calculate PIT values, takes a qp ensemble and the true z's
             pitobj = PIT(pz_data, z_true)
-            quant_ens, metamets = pitobj.evaluate()
-            pit_vals = np.array(pitobj._pit_samps)
+            metamets = pitobj.calculate_pit_meta_metrics()
             # KS
-            ksobj = PITKS(pit_vals, quant_ens)
-            ks_stat_and_pval = ksobj.evaluate()
+            ks_stat_and_pval = metamets['ks']
             print(f"KS value for code {name}: {ks_stat_and_pval.statistic}")
-            cvmobj = PITCvM(pit_vals, quant_ens)
-            cvm_stat_and_pval = cvmobj.evaluate()
+            cvm_stat_and_pval = metamets['cvm']
             print(f"CvM value for code {name}: {cvm_stat_and_pval.statistic}")
             cdelossobj = CDELoss(pz_data, zgrid, z_true)
             cde_stat_and_pval = cdelossobj.evaluate()
@@ -194,7 +191,7 @@ def main():
                 tmpname = f"{figdir}/{name}_ksplot.jpg"
                 ks_plot(pitobj, 101, True, tmpname)
 
-            pit_out_rate = PITOutRate(pit_vals, quant_ens).evaluate()
+            pit_out_rate = metamets['outlier_rate'][0]
             print(f"PIT Outlier Rate for code {name}: {pit_out_rate}")
 
             z_mode = pz_data.mode(grid=zgrid)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,13 +29,14 @@ dependencies = [
     "minisom",
     "scipy>=1.9.0",
     "pz-hyperbolic-temp",
-    "qp-prob==0.7.0",
+    "qp-prob>=0.7.1",
     "scikit-learn",
     "pzflow",
     "healpy",
     "photerr",
     "pathos",
     "somoclu",
+    "deprecated",
 ]
 
 [project.optional-dependencies]

--- a/src/rail/evaluation/evaluator.py
+++ b/src/rail/evaluation/evaluator.py
@@ -12,12 +12,12 @@ from rail.core.stage import RailStage
 
 from rail.evaluation.utils import stat_and_pval
 from rail.evaluation.metrics.cdeloss import CDELoss
-from rail.evaluation.metrics.pit import PIT, PITOutRate, PITKS, PITCvM
+from qp.metrics.pit import PIT
 from rail.evaluation.metrics.pointestimates import PointSigmaIQR, PointBias, PointOutlierRate, PointSigmaMAD
 
 
 class Evaluator(RailStage):
-    """Evalute the preformance of a photo-Z estimator """
+    """Evaluate the performance of a photo-Z estimator """
 
     name = 'Evaluator'
     config_options = RailStage.config_options.copy()
@@ -26,7 +26,7 @@ class Evaluator(RailStage):
                           nzbins=Param(int, 301, msg="# of bins in zgrid"),
                           pit_metrics=Param(str, 'all', msg='PIT-based metrics to include'),
                           point_metrics=Param(str, 'all', msg='Point-estimate metrics to include'),
-                          do_cde=Param(bool, True, msg='Evalute CDE Metric'))
+                          do_cde=Param(bool, True, msg='Evaluate CDE Metric'))
     inputs = [('input', QPHandle),
               ('truth', Hdf5Handle)]
     outputs = [('output', Hdf5Handle)]
@@ -82,13 +82,36 @@ class Evaluator(RailStage):
         z_true = self.get_data('truth')['redshift']
         zgrid = np.linspace(self.config.zmin, self.config.zmax, self.config.nzbins+1)
 
-        PIT_METRICS = dict(KS=PITKS,
-                           CvM=PITCvM,
-                           OutRate=PITOutRate)
+        # Create an instance of the PIT class
+        pitobj = PIT(pz_data, z_true)
+
+        # Build reference dictionary of the PIT meta-metrics from this PIT instance
+        PIT_METRICS = dict(
+            AD=getattr(pitobj, 'evaluate_PIT_anderson_ksamp'),
+            CvM=getattr(pitobj, 'evaluate_PIT_CvM'),
+            KS=getattr(pitobj, 'evaluate_PIT_KS'),
+            OutRate=getattr(pitobj, 'evaluate_PIT_outlier_rate'),
+        )
+
+        # Parse the input configuration to determine which meta-metrics should be calculated
         if self.config.pit_metrics == 'all':
             pit_metrics = list(PIT_METRICS.keys())
         else:  #pragma: no cover
             pit_metrics = self.config.pit_metrics.split()
+
+        # Evaluate each of the requested meta-metrics, and store the result in `out_table`
+        out_table = {}
+        for pit_metric in pit_metrics:
+            value = PIT_METRICS[pit_metric]()
+
+            # The result objects of some meta-metrics are bespoke scipy objects with inconsistent fields.
+            # Here we do our best to store the relevant fields in `out_table`.
+            if isinstance(value, list):
+                out_table[f'PIT_{pit_metric}'] = value
+            else:
+                out_table[f'PIT_{pit_metric}_stat'] = [getattr(value, 'statistic', None)]
+                out_table[f'PIT_{pit_metric}_pval'] = [getattr(value, 'p_value', None)]
+                out_table[f'PIT_{pit_metric}_significance_level'] = [getattr(value, 'significance_level', None)]
 
         POINT_METRICS = dict(SimgaIQR=PointSigmaIQR,
                              Bias=PointBias,
@@ -98,21 +121,6 @@ class Evaluator(RailStage):
             point_metrics = list(POINT_METRICS.keys())
         else:  #pragma: no cover
             point_metrics = self.config.point_metrics.split()
-
-        out_table = {}
-        pitobj = None
-        for pit_metric in pit_metrics:
-            if pitobj is None:
-                pitobj = PIT(pz_data, z_true)
-                quant_ens, _ = pitobj.evaluate()
-                pit_vals = np.array(pitobj.pit_samps)
-
-            value = PIT_METRICS[pit_metric](pit_vals, quant_ens).evaluate()
-            if isinstance(value, stat_and_pval):
-                out_table[f'PIT_{pit_metric}_stat'] = [value.statistic]
-                out_table[f'PIT_{pit_metric}_pval'] = [value.p_value]
-            elif isinstance(value, float):
-                out_table[f'PIT_{pit_metric}'] = [value]
 
         z_mode = None
         for point_metric in point_metrics:

--- a/src/rail/evaluation/metrics/brier.py
+++ b/src/rail/evaluation/metrics/brier.py
@@ -1,7 +1,14 @@
 import logging
 import numpy as np
+from deprecated import deprecated
 from .base import MetricEvaluator
 
+@deprecated(
+    reason="""
+    This implementation of the Brier metric is deprecated.
+    Please use qp.metrics.calculate_brier(prediction, truth) from the qp-prob package.
+    """,
+    category=DeprecationWarning)
 class Brier(MetricEvaluator):
     """ Brier score """
     def __init__(self, prediction, truth):

--- a/src/rail/evaluation/metrics/pit.py
+++ b/src/rail/evaluation/metrics/pit.py
@@ -92,7 +92,7 @@ class PIT(MetricEvaluator):
 @deprecated(
     reason="""
     This class is deprecated.
-    It has been superseded the qp.metrics.pit.PIT class in the qp-prob package.
+    It has been superseded by the qp.metrics.pit.PIT class in the qp-prob package.
     """,
     category=DeprecationWarning)
 class PITMeta():

--- a/src/rail/evaluation/metrics/pit.py
+++ b/src/rail/evaluation/metrics/pit.py
@@ -2,6 +2,7 @@ import inspect
 import numpy as np
 from scipy import stats
 import qp
+from deprecated import deprecated
 from .base import MetricEvaluator
 from rail.evaluation.utils import stat_and_pval, stat_crit_sig
 
@@ -18,7 +19,12 @@ def PITMetaMetric(cls):
         _pitMetaMetrics.setdefault(cls, {})["default"] = kwargs
     return cls
 
-
+@deprecated(
+    reason="""
+    This implementation of PIT is deprecated.
+    Please use qp.metrics.pit.PIT(qp_ens, z_true, quant_grid) from the qp package.
+    """,
+    category=DeprecationWarning)
 class PIT(MetricEvaluator):
     """ Probability Integral Transform """
 
@@ -83,6 +89,12 @@ class PIT(MetricEvaluator):
     #     return fig_filename
 
 
+@deprecated(
+    reason="""
+    This class is deprecated.
+    It has been superseded the qp.metrics.pit.PIT class in the qp-prob package.
+    """,
+    category=DeprecationWarning)
 class PITMeta():
     """ A superclass for metrics of the PIT"""
 
@@ -112,6 +124,12 @@ class PITMeta():
         raise NotImplementedError
 
 
+@deprecated(
+    reason="""
+    This class is deprecated.
+    It has been incorporated into the qp.metrics.pit.PIT class in the qp-prob package.
+    """,
+    category=DeprecationWarning)
 @PITMetaMetric
 class PITOutRate(PITMeta):
     """ Fraction of PIT outliers """
@@ -122,6 +140,12 @@ class PITOutRate(PITMeta):
         return out_area
 
 
+@deprecated(
+    reason="""
+    This class is deprecated.
+    It has been incorporated into the qp.metrics.pit.PIT class in the qp-prob package.
+    """,
+    category=DeprecationWarning)
 @PITMetaMetric
 class PITKS(PITMeta):
     """ Kolmogorov-Smirnov test statistic """
@@ -132,7 +156,12 @@ class PITKS(PITMeta):
         stat, pval = stats.kstest(self._pit_vals, 'uniform')
         return stat_and_pval(stat, pval)
 
-
+@deprecated(
+    reason="""
+    This class is deprecated.
+    It has been incorporated into the qp.metrics.pit.PIT class in the qp-prob package.
+    """,
+    category=DeprecationWarning)
 @PITMetaMetric
 class PITCvM(PITMeta):
     """ Cramer-von Mises statistic """
@@ -144,7 +173,12 @@ class PITCvM(PITMeta):
         return stat_and_pval(cvm_stat_and_pval.statistic,
                              cvm_stat_and_pval.pvalue)
 
-
+@deprecated(
+    reason="""
+    This class is deprecated.
+    It has been incorporated into the qp.metrics.pit.PIT class in the qp-prob package.
+    """,
+    category=DeprecationWarning)
 @PITMetaMetric
 class PITAD(PITMeta):
     """ Anderson-Darling statistic """

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -39,7 +39,7 @@ def construct_test_ensemble():
 def test_pit_metrics():
     zgrid, zspec, pdf_ens, _ = construct_test_ensemble()
     pit_obj = PIT(pdf_ens, zspec)
-    pit_vals = pit_obj._pit_samps
+    pit_vals = pit_obj.pit_samps
     quant_grid = np.linspace(0, 1, 101)
     quant_ens, metametrics = pit_obj.evaluate(quant_grid)
     out_rate = PITOutRate(pit_vals, quant_ens).evaluate()


### PR DESCRIPTION
- Updated pinned qp-prob version. 
- Marked Brier and PIT metrics as deprecated. 
- Updated usages of Brier and PIT to use the qp implementation.