### PR TITLE
switch np.int to just int

### DIFF
--- a/src/rail/estimation/algos/somocluSOM.py
+++ b/src/rail/estimation/algos/somocluSOM.py
@@ -66,7 +66,7 @@ def get_bmus(som, data, step=1000):  # pragma: no cover
     n_chunk = int(np.ceil(len(data) / step))
     with ProcessPool() as p:
         bmus = p.map(func, np.arange(n_chunk))
-    bmus_array = np.asarray(bmus).astype(np.int)
+    bmus_array = np.asarray(bmus).astype(int)
     return bmus_array.reshape(bmus_array.shape[0] * bmus_array.shape[1], 2)[:len(data)]
 
 


### PR DESCRIPTION
A trivial PR to change the now deprecated `np.int` to `int` in somocluSOM.py which was causing a test failure starting with numpy v1.24.