### PR TITLE
Updating the docs section on bpz installation

### DIFF
--- a/.github/workflows/rebuild-notebooks.yaml
+++ b/.github/workflows/rebuild-notebooks.yaml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
   
   schedule:
-      - cron: '50 16 * * 1'
+      - cron: '50 16 1 * *'
 
 jobs:
   notebook_update:

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -103,7 +103,7 @@ But if you run into problems you might need to:
 Installing bpz_lite
 -------------------
 
-For FZBoost, you should be able to just do
+For bpz_lite, you should be able to just do
 
 .. code-block:: bash
 
@@ -114,6 +114,22 @@ But if you run into problems you might need to:
 - cd to a directory where you wish to clone the DESC_BPZ package and run `git clone https://github.com/LSSTDESC/DESC_BPZ.git`
 - cd to the DESC_BPZ directory and run `python setup.py install` (add `--user` if you are on a shared system such as NERSC)
 - try `pip install pz-rail-bpz` again.
+
+If you've installed rail and bpz to different directories (most commonly, you've installed rail from 
+source and bpz from PyPI), you may run into an issue where rail cannot locate a file installed by bpz 
+(usually encountered when running the estimation step in Goldenspike). 
+
+To fix this, find your test_bpz.columns file in your bpz directory (`or grab a new one here on 
+GitHub <https://github.com/LSSTDESC/rail_bpz/blob/main/src/rail/examples/estimation/configs/test_bpz.columns>`_) 
+and copy it into your rail directory to `/RAIL/src/rail/examples/estimation/configs/test_bpz.columns`.
+
+Alternatively, if you don't want to move files, you should be able to replace the configured paths with 
+your actual `test_bpz.columns` path:
+
+* inform stage: `bpz_lite.py L89 <https://github.com/LSSTDESC/rail_bpz/blob/65870ffd93ba35356a1af44104a0a78530085789/src/rail/estimation/algos/bpz_lite.py#L89>`_
+
+* estimation: `bpz_lite.py L259 <https://github.com/LSSTDESC/rail_bpz/blob/65870ffd93ba35356a1af44104a0a78530085789/src/rail/estimation/algos/bpz_lite.py#L259>`_
+
 
 
 Using GPU-optimization for pzflow

--- a/examples/goldenspike/goldenspike.ipynb
+++ b/examples/goldenspike/goldenspike.ipynb
@@ -464,6 +464,27 @@
    ]
   },
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "29d6f99e",
+   "metadata": {},
+   "source": [
+    "\n",
+    "**If you run into issues here:** \n",
+    "\n",
+    "If you've installed rail and bpz to different directories (most commonly, you've installed rail from \n",
+    "source and bpz from PyPI), you may run into an issue where rail cannot locate a file installed by bpz.\n",
+    "\n",
+    "To fix this, find your test_bpz.columns file in your bpz directory ([or grab a new one here on \n",
+    "GitHub](https://github.com/LSSTDESC/rail_bpz/blob/main/src/rail/examples/estimation/configs/test_bpz.columns>)) \n",
+    "and copy it into your rail directory to `/RAIL/src/rail/examples/estimation/configs/test_bpz.columns`. \n",
+    "\n",
+    "Alternatively, if you don't want to move files, you should be able rewrite code to replace the configured paths with \n",
+    "your actual `test_bpz.columns` path (inform stage: [bpz_lite.py L89](https://github.com/LSSTDESC/rail_bpz/blob/65870ffd93ba35356a1af44104a0a78530085789/src/rail/estimation/algos/bpz_lite.py#L89) and estimation: [bpz_lite.py L259](https://github.com/LSSTDESC/rail_bpz/blob/65870ffd93ba35356a1af44104a0a78530085789/src/rail/estimation/algos/bpz_lite.py#L259>)).\n",
+    "\n"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "colonial-trailer",
    "metadata": {},
@@ -764,6 +785,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "temprail",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -774,12 +800,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "3eb7d322b3189fc0d051e46971545e8423a3ccd97a3e6ee97c9e2a28f48eb9d8"
-   }
+   "version": "3.9.16"
   }
  },
  "nbformat": 4,

--- a/examples/goldenspike/goldenspike.ipynb
+++ b/examples/goldenspike/goldenspike.ipynb
@@ -785,11 +785,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "temprail",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -800,7 +795,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
A small update to the docs as proposed in LSSTDESC/rail_bpz#29, giving a little troubleshooting explanation to tide us over until the blocking dependencies let bpz get updated on PyPI.