### PR TITLE
Add @v0.2.0 to dsps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "somoclu",
     "diffstar@git+https://github.com/ArgonneCPAC/diffstar",
     "diffmah@git+https://github.com/ArgonneCPAC/diffmah",
-    "dsps@git+https://github.com/ArgonneCPAC/dsps",
+    "dsps@git+https://github.com/ArgonneCPAC/dsps@v0.2.0",
     "deprecated",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,8 @@ dependencies = [
     "photerr",
     "pathos",
     "somoclu",
-    "diffstar@git+https://github.com/ArgonneCPAC/diffstar",
-    "diffmah@git+https://github.com/ArgonneCPAC/diffmah",
+    "diffstar@git+https://github.com/ArgonneCPAC/diffstar@v0.1.0",
+    "diffmah@git+https://github.com/ArgonneCPAC/diffmah@v0.4.1",
     "dsps@git+https://github.com/ArgonneCPAC/dsps@v0.2.0",
     "deprecated",
 ]


### PR DESCRIPTION
Addresses the failure for dsps-related tests that we've been seeing in our CI the past week.

We import dsps from CPAC's GitHub, so I went ahead and added version specifiers for the other two repos we import from them, as well.