### PR TITLE
Move hardcoded variable names in two estimation stages to config params

### DIFF
--- a/src/rail/estimation/algos/randomPZ.py
+++ b/src/rail/estimation/algos/randomPZ.py
@@ -22,7 +22,8 @@ class RandomPZ(CatEstimator):
     config_options.update(rand_width=Param(float, 0.025, "ad hock width of PDF"),
                           rand_zmin=Param(float, 0.0, msg="The minimum redshift of the z grid"),
                           rand_zmax=Param(float, 3.0, msg="The maximum redshift of the z grid"),
-                          nzbins=Param(int, 301, msg="The number of gridpoints in the z grid"))
+                          nzbins=Param(int, 301, msg="The number of gridpoints in the z grid"),
+                          column_name=Param(str, "mag_i_lsst", msg="name of a column that has the correct number of galaxies to find length of"))
 
     def __init__(self, args, comm=None):
         """ Constructor:
@@ -33,17 +34,13 @@ class RandomPZ(CatEstimator):
     def _process_chunk(self, start, end, data, first):
         pdf = []
         # allow for either format for now
-        try:
-            d = data['i_mag']
-        except Exception:
-            d = data['mag_i_lsst']
-        numzs = len(d)
+        numzs = len(data[self.config.column_name])
         zmode = np.round(np.random.uniform(0.0, self.config.rand_zmax, numzs), 3)
         widths = self.config.rand_width * (1.0 + zmode)
         self.zgrid = np.linspace(self.config.rand_zmin, self.config.rand_zmax, self.config.nzbins)
         for i in range(numzs):
             pdf.append(norm.pdf(self.zgrid, zmode[i], widths[i]))
-        qp_d = qp.Ensemble(qp.stats.norm, data=dict(loc=np.expand_dims(zmode, -1),  #pylint: disable=no-member
+        qp_d = qp.Ensemble(qp.stats.norm, data=dict(loc=np.expand_dims(zmode, -1),  # pylint: disable=no-member
                                                     scale=np.expand_dims(widths, -1)))
         qp_d.set_ancil(dict(zmode=zmode))
         self._do_chunk_output(qp_d, start, end, first)

--- a/src/rail/estimation/algos/trainZ.py
+++ b/src/rail/estimation/algos/trainZ.py
@@ -6,6 +6,7 @@ N (z) of the training set.
 """
 
 import numpy as np
+from ceci.config import StageParameter as Param
 from rail.estimation.estimator import CatEstimator, CatInformer
 from rail.core.common_params import SHARED_PARAMS
 import qp
@@ -30,8 +31,8 @@ class Inform_trainZ(CatInformer):
     config_options = CatInformer.config_options.copy()
     config_options.update(zmin=SHARED_PARAMS,
                           zmax=SHARED_PARAMS,
-                          nzbins=SHARED_PARAMS)
-
+                          nzbins=SHARED_PARAMS,
+                          redshift_column_name=Param(str, 'redshift', msg="str, name of the redshift column"))
 
     def __init__(self, args, comm=None):
         CatInformer.__init__(self, args, comm=comm)
@@ -39,17 +40,17 @@ class Inform_trainZ(CatInformer):
     def run(self):
         if self.config.hdf5_groupname:
             training_data = self.get_data('input')[self.config.hdf5_groupname]
-        else:  #pragma: no cover
+        else:  # pragma: no cover
             training_data = self.get_data('input')
-        zbins = np.linspace(self.config.zmin, self.config.zmax, self.config.nzbins+1)
-        speczs = np.sort(training_data['redshift'])
+        zbins = np.linspace(self.config.zmin, self.config.zmax, self.config.nzbins + 1)
+        speczs = np.sort(training_data[self.config.redshift_column_name])
         train_pdf, _ = np.histogram(speczs, zbins)
-        midpoints = zbins[:-1] + np.diff(zbins)/2
+        midpoints = zbins[:-1] + np.diff(zbins) / 2
         zmode = midpoints[np.argmax(train_pdf)]
         cdf = np.cumsum(train_pdf)
         cdf = cdf / cdf[-1]
-        norm = cdf[-1]*(zbins[2]-zbins[1])
-        train_pdf = train_pdf/norm
+        norm = cdf[-1] * (zbins[2] - zbins[1])
+        train_pdf = train_pdf / norm
         zgrid = midpoints
         self.model = trainZmodel(zgrid, train_pdf, zmode)
         self.add_data('model', self.model)
@@ -73,7 +74,7 @@ class TrainZ(CatEstimator):
 
     def open_model(self, **kwargs):
         CatEstimator.open_model(self, **kwargs)
-        if self.model is None:  #pragma: no cover
+        if self.model is None:  # pragma: no cover
             return
         self.zgrid = self.model.zgrid
         self.train_pdf = self.model.pdf


### PR DESCRIPTION
Addressing the last vestiges of issue #47 where a seldom used "dummy" photo-z code that just generates random Gaussians and our pathological case that just sets every PDF to the histogram of training values still had some hardcoded names from way back.  A couple minor linting updates like spaces around operators as well.  I tested everything and it all works in a notebook.