### PR TITLE
Issue 330: fix test variable mistake and quant name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "minisom",
     "scipy>=1.9.0",
     "pz-hyperbolic-temp",
-    "qp-prob>=0.7.1",
+    "qp-prob[full]>=0.8.1",
     "scikit-learn",
     "pzflow",
     "healpy",

--- a/src/rail/evaluation/evaluator.py
+++ b/src/rail/evaluation/evaluator.py
@@ -106,7 +106,7 @@ class Evaluator(RailStage):
 
             # The result objects of some meta-metrics are bespoke scipy objects with inconsistent fields.
             # Here we do our best to store the relevant fields in `out_table`.
-            if isinstance(value, list):
+            if isinstance(value, list):  # pragma: no cover
                 out_table[f'PIT_{pit_metric}'] = value
             else:
                 out_table[f'PIT_{pit_metric}_stat'] = [getattr(value, 'statistic', None)]

--- a/src/rail/evaluation/metrics/pit.py
+++ b/src/rail/evaluation/metrics/pit.py
@@ -55,7 +55,7 @@ class PIT(MetricEvaluator):
         if n_pit < len(eval_grid): #pragma: no cover
             eval_grid = np.linspace(0, 1, n_pit)
         data_quants = np.quantile(self._pit_samps, eval_grid)
-        pit = qp.Ensemble(qp.quant_piecewise, data=dict(quants=eval_grid, locs=np.atleast_2d(data_quants)))
+        pit = qp.Ensemble(qp.quant, data=dict(quants=eval_grid, locs=np.atleast_2d(data_quants)))
 
         #pit = qp.spline_from_samples(xvals=eval_grid,
         #                             samples=np.atleast_2d(self._pit_samps))

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -90,7 +90,7 @@ def test_evaluation_stage():
     DS = RailStage.data_store
     zgrid, zspec, pdf_ens, true_ez = construct_test_ensemble()
     pdf = DS.add_data('pdf', pdf_ens, QPHandle)
-    truth_table = dict(redshift=true_ez)
+    truth_table = dict(redshift=zspec)
     truth = DS.add_data('truth', truth_table, TableHandle)
     evaluator = Evaluator.make_stage(name='Eval')
     evaluator.evaluate(pdf, truth)


### PR DESCRIPTION
@eacharles pointed out something obvious that I missed: that the test was actually feeding in ez values rather than specz values, which somehow did not cause a crash until now.  That and changing the name from quant_piecewise to quant in one of the PIT functions now has all of the tests running for me on my local branch.