### PR TITLE
Add pip install wheel to main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,8 +31,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install wheel
-        pip install numpy
+        pip install wheel numpy # For somoclu
         pip install .[all]
         pip install flake8 pytest pytest-cov mockmpi pytest-timeout
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install wheel
         pip install numpy
         pip install .[all]
         pip install flake8 pytest pytest-cov mockmpi pytest-timeout


### PR DESCRIPTION
Fixes #333; lets RAIL run on github actions again. 

Based on the https://github.com/pypa/pip/issues/8559  deprecation thread.

Talked to someone at somoclu and this seemed the best course of action.

(Note, this adds to the explicit `pip install numpy` line we've already needed before installing somoclu: https://github.com/peterwittek/somoclu/issues/165).