### PR TITLE
Mark slow tests and run separately.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,8 @@ jobs:
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Test with pytest
       run: |
-        python -m pytest --cov=./rail --cov-report=xml
+        python -m pytest -m "not slow" --cov=./rail --cov-report=xml
+        python -m pytest -m "slow" --cov=./rail --cov-report=xml --cov-append
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
       with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,6 +136,9 @@ addopts = [
     "--cov-report=html"
 ]
 flake8-ignore = "E203"
+markers = [
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+]
 
 [tool.mypy]
 disallow_untyped_defs = true

--- a/tests/test_algos.py
+++ b/tests/test_algos.py
@@ -63,6 +63,7 @@ def test_simple_nn():
         (True, [0.15, 0.14, 0.15, 0.14, 0.12, 0.14, 0.15, 0.12, 0.13, 0.11]),
     ],
 )
+@pytest.mark.slow
 def test_pzflow(inputs, zb_expected):
     def_bands = ["u", "g", "r", "i", "z", "y"]
     refcols = [f"mag_{band}_lsst" for band in def_bands]


### PR DESCRIPTION
This registers a new mark, `@pytest.mark.slow`, that can be used to annotate test cases that are known to be slow and can be skipped for quick unit testing.

The workflow is modified to first run any tests NOT marked with slow, and on success, run the remaining slow tests. The coverage from the two runs is combined, so this does not result in any change to overall test coverage.

Additional tests will be marked as slow in upcoming PRs, once later "fast" tests no longer rely on state produced by earlier "slow" tests.