### PR TITLE
Define a new MPI communicator when data set is small

### DIFF
--- a/src/rail/core/stage.py
+++ b/src/rail/core/stage.py
@@ -6,6 +6,7 @@ from ceci import PipelineStage, MiniPipeline
 from ceci.config import StageParameter as Param
 from rail.core.data import DATA_STORE, DataHandle
 
+from math import ceil
 
 class StageIO:
     """A small utility class for Stage Input/ Output
@@ -327,6 +328,14 @@ class RailStage(PipelineStage):
         handle = self.get_handle(tag, allow_missing=True)
         if self.config.hdf5_groupname:
             self._input_length = handle.size(groupname=self.config.hdf5_groupname)
+            total_chunks_needed = ceil(self._input_length/self.config.chunk_size)
+            if total_chunks_needed<self.size:
+                color = self.rank+1 <= total_chunks_needed
+                newcomm = self.comm.Split(color=color,key=self.rank)
+                if color:
+                    self.setup_mpi(newcomm)
+                else:
+                    quit()
             kwcopy = dict(groupname=self.config.hdf5_groupname,
                           chunk_size=self.config.chunk_size,
                           rank=self.rank,

--- a/src/rail/core/stage.py
+++ b/src/rail/core/stage.py
@@ -329,7 +329,7 @@ class RailStage(PipelineStage):
         if self.config.hdf5_groupname:
             self._input_length = handle.size(groupname=self.config.hdf5_groupname)
             total_chunks_needed = ceil(self._input_length/self.config.chunk_size)
-            if total_chunks_needed<self.size:
+            if total_chunks_needed<self.size:  #pragma: no cover
                 color = self.rank+1 <= total_chunks_needed
                 newcomm = self.comm.Split(color=color,key=self.rank)
                 if color:


### PR DESCRIPTION
When data set is small, define a new communicator that only has the needed processes to compute the current model. This is written in input_iterator so that it works with any algorithm using iterators.