### PR TITLE
Use qp-based PIT metrics instead of deprecated RAIL-based PIT metrics

### DIFF
--- a/examples/evaluation_examples/demo.ipynb
+++ b/examples/evaluation_examples/demo.ipynb
@@ -326,7 +326,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# pit_out_rate = PITOutRate(pit_vals, quant_ens).evaluate()\n",
     "pit_out_rate = metamets['outlier_rate']\n",
     "print(f\"PIT outlier rate of this sample: {pit_out_rate:.6f}\") \n",
     "pit_out_rate = pitobj.evaluate_PIT_outlier_rate()\n",
@@ -604,7 +603,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.10"
+   "version": "3.10.9"
   }
  },
  "nbformat": 4,

--- a/examples/evaluation_examples/demo.ipynb
+++ b/examples/evaluation_examples/demo.ipynb
@@ -106,7 +106,7 @@
    "outputs": [],
    "source": [
     "from rail.core.utils import RAILDIR\n",
-    "pdfs_file = os.path.join(RAILDIR, 'rail/examples_data/estimation_data/data/output_fzboost.hdf5')\n",
+    "pdfs_file = os.path.join(RAILDIR, 'rail/examples_data/evaluation_data/data/output_fzboost.hdf5')\n",
     "ztrue_file = os.path.join(RAILDIR, 'rail/examples_data/testdata/test_dc2_validation_9816.hdf5')"
    ]
   },

--- a/examples/evaluation_examples/demo.ipynb
+++ b/examples/evaluation_examples/demo.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "Author: Sam Schmidt, Alex Malz, Julia Gschwend, others...\n",
     "\n",
-    "last run successfully: -\n",
+    "last run successfully: April 28, 2023 (with qp-prob >= 0.8.2)\n",
     "\n",
     "The purpose of this notebook is to demonstrate the application of the metrics scripts to be used on the photo-z PDF catalogs produced by the PZ working group. The first implementation of the _evaluation_ module is based on the refactoring of the code used in [Schmidt et al. 2020](https://arxiv.org/pdf/2001.03621.pdf), available on Github repository [PZDC1paper](https://github.com/LSSTDESC/PZDC1paper). \n",
     "\n",
@@ -327,9 +327,9 @@
    "outputs": [],
    "source": [
     "# pit_out_rate = PITOutRate(pit_vals, quant_ens).evaluate()\n",
-    "pit_out_rate = metamets['outlier_rate'][0]\n",
+    "pit_out_rate = metamets['outlier_rate']\n",
     "print(f\"PIT outlier rate of this sample: {pit_out_rate:.6f}\") \n",
-    "pit_out_rate = pitobj.evaluate_PIT_outlier_rate()[0]\n",
+    "pit_out_rate = pitobj.evaluate_PIT_outlier_rate()\n",
     "print(f\"PIT outlier rate of this sample: {pit_out_rate:.6f}\") "
    ]
   },

--- a/examples/evaluation_examples/demo.ipynb
+++ b/examples/evaluation_examples/demo.ipynb
@@ -106,7 +106,7 @@
    "outputs": [],
    "source": [
     "from rail.core.utils import RAILDIR\n",
-    "pdfs_file = \"../estimation_examples/output_fzboost.hdf5\"\n",
+    "pdfs_file = os.path.join(RAILDIR, 'rail/examples_data/estimation_data/data/output_fzboost.hdf5')\n",
     "ztrue_file = os.path.join(RAILDIR, 'rail/examples_data/testdata/test_dc2_validation_9816.hdf5')"
    ]
   },
@@ -248,8 +248,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from qp.metrics.pit import PIT\n",
     "pitobj = PIT(fzdata(), ztrue)\n",
-    "quant_ens, metamets = pitobj.evaluate()"
+    "quant_ens = pitobj.pit\n",
+    "metamets = pitobj.calculate_pit_meta_metrics()"
    ]
   },
   {
@@ -290,7 +292,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pit_vals = np.array(pitobj._pit_samps)\n",
+    "pit_vals = np.array(pitobj.pit_samps)\n",
     "pit_vals"
    ]
   },
@@ -309,7 +311,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pit_out_rate = PITOutRate(pit_vals, quant_ens).evaluate()\n",
+    "# pit_out_rate = PITOutRate(pit_vals, quant_ens).evaluate()\n",
+    "pit_out_rate = metamets['outlier_rate'][0]\n",
+    "print(f\"PIT outlier rate of this sample: {pit_out_rate:.6f}\") \n",
+    "pit_out_rate = pitobj.evaluate_PIT_outlier_rate()[0]\n",
     "print(f\"PIT outlier rate of this sample: {pit_out_rate:.6f}\") "
    ]
   },
@@ -385,17 +390,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ksobj = PITKS(pit_vals, quant_ens)\n",
-    "ks_stat_and_pval = ksobj.evaluate()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ks_stat_and_pval"
+    "ks_stat_and_pval = metamets['ks']\n",
+    "print(f\"PIT KS stat and pval: {ks_stat_and_pval}\") \n",
+    "ks_stat_and_pval = pitobj.evaluate_PIT_KS()\n",
+    "print(f\"PIT KS stat and pval: {ks_stat_and_pval}\") "
    ]
   },
   {
@@ -444,8 +442,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cvmobj = PITCvM(pit_vals, quant_ens)\n",
-    "cvm_stat_and_pval = cvmobj.evaluate()"
+    "cvm_stat_and_pval = metamets['cvm']\n",
+    "print(f\"PIT CvM stat and pval: {cvm_stat_and_pval}\") \n",
+    "cvm_stat_and_pval = pitobj.evaluate_PIT_CvM()\n",
+    "print(f\"PIT CvM stat and pval: {cvm_stat_and_pval}\")"
    ]
   },
   {
@@ -476,18 +476,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "adobj = PITAD(pit_vals, quant_ens)\n",
-    "ad_stat_crit_sig = adobj.evaluate()\n",
-    "ad_stat_crit_sig"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ad_stat_crit_sig"
+    "ad_stat_crit_sig = metamets['ad']\n",
+    "print(f\"PIT AD stat and pval: {ad_stat_crit_sig}\") \n",
+    "ad_stat_crit_sig = pitobj.evaluate_PIT_anderson_ksamp()\n",
+    "print(f\"PIT AD stat and pval: {ad_stat_crit_sig}\")"
    ]
   },
   {
@@ -512,7 +504,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ad_stat_crit_sig_cut = adobj.evaluate(pit_min=0.01, pit_max=0.99)\n",
+    "ad_stat_crit_sig_cut = pitobj.evaluate_PIT_anderson_ksamp(pit_min=0.01, pit_max=0.99)\n",
     "print(f\"AD metric of this sample: {ad_stat_crit_sig.statistic:.4f}\") \n",
     "print(f\"AD metric for 0.01 < PIT < 0.99: {ad_stat_crit_sig_cut.statistic:.4f}\") "
    ]
@@ -597,7 +589,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.10"
+   "version": "3.10.9"
   }
  },
  "nbformat": 4,

--- a/examples/evaluation_examples/demo.ipynb
+++ b/examples/evaluation_examples/demo.ipynb
@@ -85,11 +85,11 @@
     "### Photo-z Results\n",
     "#### Run FZBoost\n",
     "\n",
-    "Go to dir  `<your_path>/RAIL/examples/estimation_examples/` and run the notebook `RAIL_estimation_demo.ipynb`, this will produce a file `output_fzboost.fits`\n",
-    "\n",
+    "If you have run the notebook `RAIL_estimation_demo.ipynb`, this will produce a file `output_fzboost.fits`, \n",
     "writen at the location:<br> \n",
     "`<your_path>/RAIL/examples/estimation_examples/output_fzboost.fits`. \n",
-    "This will run FZBoost and write out the PDF results as a qp Ensemble that we will then use in this example notebook.\n"
+    "\n",
+    "Otherwise we can download the file from NERSC\n"
    ]
   },
   {
@@ -108,6 +108,21 @@
     "from rail.core.utils import RAILDIR\n",
     "pdfs_file = os.path.join(RAILDIR, 'rail/examples_data/evaluation_data/data/output_fzboost.hdf5')\n",
     "ztrue_file = os.path.join(RAILDIR, 'rail/examples_data/testdata/test_dc2_validation_9816.hdf5')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if not os.path.exists(pdfs_file):\n",
+    "    try:\n",
+    "        os.makedirs(os.path.dirname(pdfs_file))\n",
+    "    except FileExistsError:\n",
+    "        pass\n",
+    "    curl_com = f\"curl -o {pdfs_file} https://portal.nersc.gov/cfs/lsst/schmidt9/output_fzboost.hdf5\"\n",
+    "    os.system(curl_com)\n"
    ]
   },
   {
@@ -589,7 +604,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "version": "3.10.10"
   }
  },
  "nbformat": 4,

--- a/examples/goldenspike_examples/goldenspike.ipynb
+++ b/examples/goldenspike_examples/goldenspike.ipynb
@@ -8,7 +8,7 @@
     "# Goldenspike, an example of an end-to-end analysis using RAIL\n",
     "\n",
     "author: Sam Schmidt, Eric Charles, Alex Malz, John Franklin Crenshaw, others...<br>\n",
-    "last run successfully: April 15, 2022\n",
+    "last run successfully: April 28, 2023 (with qp-prob >= 0.8.2)\n",
     "\n",
     "This notebook demonstrates how to use a the various RAIL Modules to draw synthetic samples of fluxes by color, apply physical effects to them, train photo-Z estimators on the samples, test and validate the preformance of those estimators, and to use the RAIL summarization modules to obtain n(z) estimates based on the p(z) estimates.\n",
     "\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dev = [
     "pylint",
     "pytest",
     "pytest-cov",
+    "seaborn",
     "yamllint",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "minisom",
     "scipy>=1.9.0",
     "pz-hyperbolic-temp",
-    "qp-prob[full]>=0.8.1",
+    "qp-prob[full]>=0.8.3",
     "scikit-learn",
     "pzflow",
     "healpy",

--- a/src/rail/core/utilStages.py
+++ b/src/rail/core/utilStages.py
@@ -152,8 +152,9 @@ class LSSTFluxToMagConverter(RailStage):
             flux_err_col_name = self.config.flux_err_name.format(band=band_)
             out_data[self.config.mag_name.format(band=band_)] = self._flux_to_mag(data[flux_col_name].values)
             out_data[self.config.mag_err_name.format(band=band_)] = self._flux_err_to_mag_err(data[flux_col_name].values, data[flux_err_col_name].values)
+
         for col_ in self.config.copy_cols:  # pragma: no cover
-            out_data[col_] = data[col_]
+            out_data[col_] = data[col_].values
         self.add_data('output', out_data)
 
     def __call__(self, data):


### PR DESCRIPTION
Fixed references to PIT metric implementations in RAIL, now points to qp implementations. Added output file to estimation_data/data dir.