### PR TITLE
Addressing the last few remaining places where randoms aren't using default_rng and/or a configurable seed

### DIFF
--- a/src/rail/creation/degradation/grid_selection.py
+++ b/src/rail/creation/degradation/grid_selection.py
@@ -73,7 +73,7 @@ class GridSelection(Degrader):
         If using a color-based redshift cut, galaxies with redshifts > the percentile cut are removed from the sample
         before making the random selection.
         """
-        np.random.seed(self.config.random_seed)
+        rng = np.random.default_rng(seed=self.config.random_seed)
 
         data = self.get_data('input')
         with open(self.config.settings_file, 'rb') as handle:
@@ -189,13 +189,13 @@ class GridSelection(Degrader):
                 number_to_keep = len(temp_data)
 
             if int(number_to_keep) != number_to_keep:
-                random_num = np.random.uniform()
+                random_num = rng.uniform()
             else:
                 random_num = 2
 
             number_to_keep = np.floor(number_to_keep)
             indices_to_list = list(temp_data.index.values)
-            np.random.shuffle(indices_to_list)
+            rng.shuffle(indices_to_list)
 
             if random_num > xratio:  # pragma: no cover
                 for j in range(int(number_to_keep)):

--- a/src/rail/estimation/algos/knnpz.py
+++ b/src/rail/estimation/algos/knnpz.py
@@ -106,8 +106,8 @@ class Inform_KNearNeighPDF(CatInformer):
         trainszs = np.array(training_data[self.config.redshift_column_name])
         colordata = _computecolordata(knndf, self.config.ref_column_name, self.config.column_names)
         nobs = colordata.shape[0]
-        rng = np.random.default_rng
-        perm = rng().permutation(nobs)
+        rng = np.random.default_rng(seed=self.config.seed)
+        perm = rng.permutation(nobs)
         ntrain = round(nobs * self.config.trainfrac)
         xtrain_data = colordata[perm[:ntrain]]
         train_data = copy.deepcopy(xtrain_data)

--- a/src/rail/estimation/algos/randomPZ.py
+++ b/src/rail/estimation/algos/randomPZ.py
@@ -36,7 +36,7 @@ class RandomPZ(CatEstimator):
         pdf = []
         # allow for either format for now
         numzs = len(data[self.config.column_name])
-        rng = np.random.default_rng(seed=self.config.seed)
+        rng = np.random.default_rng(seed=self.config.seed + start)
         zmode = np.round(rng.uniform(0.0, self.config.rand_zmax, numzs), 3)
         widths = self.config.rand_width * (1.0 + zmode)
         self.zgrid = np.linspace(self.config.rand_zmin, self.config.rand_zmax, self.config.nzbins)

--- a/src/rail/estimation/algos/randomPZ.py
+++ b/src/rail/estimation/algos/randomPZ.py
@@ -23,6 +23,7 @@ class RandomPZ(CatEstimator):
                           rand_zmin=Param(float, 0.0, msg="The minimum redshift of the z grid"),
                           rand_zmax=Param(float, 3.0, msg="The maximum redshift of the z grid"),
                           nzbins=Param(int, 301, msg="The number of gridpoints in the z grid"),
+                          seed=Param(int, 87, msg="random seed"),
                           column_name=Param(str, "mag_i_lsst", msg="name of a column that has the correct number of galaxies to find length of"))
 
     def __init__(self, args, comm=None):
@@ -35,7 +36,8 @@ class RandomPZ(CatEstimator):
         pdf = []
         # allow for either format for now
         numzs = len(data[self.config.column_name])
-        zmode = np.round(np.random.uniform(0.0, self.config.rand_zmax, numzs), 3)
+        rng = np.random.default_rng(seed=self.config.seed)
+        zmode = np.round(rng.uniform(0.0, self.config.rand_zmax, numzs), 3)
         widths = self.config.rand_width * (1.0 + zmode)
         self.zgrid = np.linspace(self.config.rand_zmin, self.config.rand_zmax, self.config.nzbins)
         for i in range(numzs):


### PR DESCRIPTION
addressing #41, I looked for instances where we were not using numpy.random.default_rng, and/or were not setting the seed from a config parameter for the stage.  With all stages that use a random number generator, using default_rng and a configurable seed should allow us to isolate the effects of the rng to the particular stage, and easily change via the config parameter to test effects of the randoms on stage performance.